### PR TITLE
Fix reproducing paper experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you find the code useful, please refer to our work using:
 
 ## Installation
 
-The experiments were ran using python 3.11.6. The easiest way to set up the requirements is by creating a virtualenvironment and running: 
+The experiments require *Python 3.11* (we ran using Python 3.11.6). The easiest way to set up the requirements is by creating a virtualenvironment and running: 
 ```
 pip install -r requirements.txt
 ```

--- a/experiments/figures/experiment_1_disruptions.ipynb
+++ b/experiments/figures/experiment_1_disruptions.ipynb
@@ -126,7 +126,8 @@
     "        fe_threshold=-14.8,\n",
     "        name=agent_mode.name,\n",
     "    )\n",
-    "    agent.model_pf.agent.gamma = gamma\n",
+    "    if agent_mode != AgentModes.RANDOM:\n",
+    "        agent.model_pf.agent.gamma = gamma\n",
     "\n",
     "    controls = {AgentModes.RANDOM: [True]}\n",
     "\n",
@@ -217,7 +218,6 @@
     "    # only consider the corridor ends\n",
     "    corridors = df[df[\"pos_y\"] == 1]\n",
     "    corridors = corridors[corridors[\"pos_dir\"] == 3]\n",
-    "    #corridors = corridors[corridors['time'] > 50]\n",
     "\n",
     "    grouped = corridors.groupby([\"control_mode\", \"trial\", \"inbound\"]).mean([\"reward\"]).reset_index()\n",
     "\n",
@@ -768,7 +768,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/experiments/figures/experiment_2_multiple_rules.ipynb
+++ b/experiments/figures/experiment_2_multiple_rules.ipynb
@@ -201,13 +201,13 @@
     "    cycle=True\n",
     ")\n",
     "\n",
-    "# run_experiment(\n",
-    "    # AgentModes.CSCG_LOC, \n",
-    "    # store_path, \n",
-    "    # n_trials=n_trials, \n",
-    "    # n_steps=n_steps, \n",
-    "    # cycle=False\n",
-    "# )"
+    "run_experiment(\n",
+    "    AgentModes.CSCG_LOC, \n",
+    "    store_path, \n",
+    "    n_trials=n_trials, \n",
+    "    n_steps=n_steps, \n",
+    "    cycle=False\n",
+    ")"
    ]
   },
   {
@@ -253,13 +253,13 @@
     "    cycle=True\n",
     ")\n",
     "\n",
-    "# run_experiment(\n",
-    "#     AgentModes.CSCG_LOC_RULE0, \n",
-    "#     store_path, \n",
-    "#     n_trials=n_trials, \n",
-    "#     n_steps=n_steps, \n",
-    "#     cycle=False\n",
-    "# )"
+    "run_experiment(\n",
+    "    AgentModes.CSCG_LOC_RULE0, \n",
+    "    store_path, \n",
+    "    n_trials=n_trials, \n",
+    "    n_steps=n_steps, \n",
+    "    cycle=False\n",
+    ")"
    ]
   },
   {
@@ -734,7 +734,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/hippo/agents/prefrontal_agent.py
+++ b/hippo/agents/prefrontal_agent.py
@@ -242,8 +242,8 @@ class PrefrontalCSCGModel:
             C=C,
             gamma=gamma,
             action_selection="stochastic",
-            policies=self.construct_policies(1),
         )
+        self.agent.policies = self.construct_policies(1)
         self.prev_action = 0
 
         self.pE = np.ones_like(self.agent.E)


### PR DESCRIPTION
Small fixes for reproducing experiments:
- gamma cannot be set for random agent
- workaround wrong None check in pymdp
- uncomment / remove commented lines that were left after debugging
- stress Python 3.11 requirement in readme